### PR TITLE
Merge upstream changes

### DIFF
--- a/plugins/fzf/fzf.plugin.zsh
+++ b/plugins/fzf/fzf.plugin.zsh
@@ -7,6 +7,7 @@ function setup_using_base_dir() {
         fzfdirs=(
           "${HOME}/.fzf"
           "${HOME}/.nix-profile/share/fzf"
+          "${XDG_DATA_HOME:-$HOME/.local/share}/fzf"
           "/usr/local/opt/fzf"
           "/usr/share/fzf"
           "/usr/local/share/examples/fzf"

--- a/plugins/systemadmin/systemadmin.plugin.zsh
+++ b/plugins/systemadmin/systemadmin.plugin.zsh
@@ -131,7 +131,8 @@ d0() {
 
 # gather external ip address
 geteip() {
-    curl -s -S https://icanhazip.com
+    curl -s -S -4 https://icanhazip.com
+    curl -s -S -6 https://icanhazip.com
 }
 
 # determine local IP address(es)

--- a/themes/ys.zsh-theme
+++ b/themes/ys.zsh-theme
@@ -26,10 +26,12 @@ ys_hg_prompt_info() {
 	if [ -d '.hg' ]; then
 		echo -n "${YS_VCS_PROMPT_PREFIX1}hg${YS_VCS_PROMPT_PREFIX2}"
 		echo -n $(hg branch 2>/dev/null)
-		if [ -n "$(hg status 2>/dev/null)" ]; then
-			echo -n "$YS_VCS_PROMPT_DIRTY"
-		else
-			echo -n "$YS_VCS_PROMPT_CLEAN"
+		if [[ "$(hg config oh-my-zsh.hide-dirty 2>/dev/null)" != "1" ]]; then
+			if [ -n "$(hg status 2>/dev/null)" ]; then
+				echo -n "$YS_VCS_PROMPT_DIRTY"
+			else
+				echo -n "$YS_VCS_PROMPT_CLEAN"
+			fi
 		fi
 		echo -n "$YS_VCS_PROMPT_SUFFIX"
 	fi

--- a/themes/ys.zsh-theme
+++ b/themes/ys.zsh-theme
@@ -37,6 +37,15 @@ ys_hg_prompt_info() {
 	fi
 }
 
+# Virtualenv
+local venv_info='$(virtenv_prompt)'
+YS_THEME_VIRTUALENV_PROMPT_PREFIX=" %{$fg[green]%}"
+YS_THEME_VIRTUALENV_PROMPT_SUFFIX=" %{$reset_color%}%"
+virtenv_prompt() {
+	[[ -n ${VIRTUAL_ENV} ]] || return
+	echo "${YS_THEME_VIRTUALENV_PROMPT_PREFIX}${VIRTUAL_ENV:t}${YS_THEME_VIRTUALENV_PROMPT_SUFFIX}"
+}
+
 local exit_code="%(?,,C:%{$fg[red]%}%?%{$reset_color%})"
 
 # Prompt format:
@@ -57,6 +66,7 @@ PROMPT="
 %{$terminfo[bold]$fg[yellow]%}%~%{$reset_color%}\
 ${hg_info}\
 ${git_info}\
+${venv_info}\
  \
 %{$fg[white]%}[%*] $exit_code
 %{$terminfo[bold]$fg[red]%}$ %{$reset_color%}"


### PR DESCRIPTION
On large mercurial projects, using `hg status` to show dirty prompt
causes significant delay.

This commit checks a local hg config value of `oh-my-zsh.hide-dirty` to
skip dirty check.

Users who wish to skip dirty check can add this to their `.hg/hgrc`
file.

```
[oh-my-zsh]
hide-dirty = 1
```

This config value uses the same naming as ones found for git, in file
lib/git.zsh.## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
